### PR TITLE
Null-safety for flutter 2.0

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -4,7 +4,7 @@ class Currency extends StatelessWidget {
   // init Currency
   final String currencyName;
 
-  Currency({Key key, @required this.currencyName}) : super(key: key);
+  Currency({Key? key, required this.currencyName}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -13,8 +13,7 @@ class Currency extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           ListTile(
-              leading: Image.asset('icons/currency/${this.currencyName}.png',
-                  package: 'currency_icons'),
+              leading: Image.asset('icons/currency/${this.currencyName}.png', package: 'currency_icons'),
               title: Text(this.currencyName)),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: currency_icons
 description: A flutter package to display currency flag. Just specify currency name when creating a new Image.
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/cychiang/currency-icons
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_launcher_icons: ^0.8.1
+  flutter_launcher_icons: ^0.9.0
 
 flutter:
   assets:


### PR DESCRIPTION
Following the migration guide to staying current with Flutter 2.0 (https://dart.dev/null-safety/migration-guide).